### PR TITLE
Add parent page scroll lock message

### DIFF
--- a/script.js
+++ b/script.js
@@ -23,6 +23,14 @@ window.addEventListener("message", (event) => {
       }
       break
     }
+    case 'parentScroll': {
+      if(event.data.payload?.enable) {
+        document.documentElement.classList.remove('device-height')
+      } else {
+        document.documentElement.classList.add('device-height')
+      }
+      break
+    }
   }
 })
 


### PR DESCRIPTION
Iframe will send parentScroll message with payload "enable" (boolean value)
![image](https://github.com/user-attachments/assets/b6f632b1-f195-47de-aac8-53a586216673)

When enabled, the parent page won't be scrolled

Needed for https://github.com/advbet/sportsbook-iframe-ui/pull/1269